### PR TITLE
mesh: fix bug & delete not accessed imports

### DIFF
--- a/fealpy/mesh/TriangleMesh.py
+++ b/fealpy/mesh/TriangleMesh.py
@@ -1,11 +1,11 @@
 import numpy as np
 import warnings
-from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, spdiags, bmat, eye
+from scipy.sparse import coo_matrix, csr_matrix, bmat, eye
 from scipy.spatial import KDTree
 from .Mesh2d import Mesh2d, Mesh2dDataStructure
 from ..quadrature import TriangleQuadrature
 from ..quadrature import GaussLegendreQuadrature
-from fealpy.mesh.TriangleMeshData import gphigphiphi,phiphi,gphigphi,gphiphi,phigphiphi,phiphiphi
+
 
 class TriangleMeshDataStructure(Mesh2dDataStructure):
 
@@ -60,7 +60,7 @@ class TriangleMesh(Mesh2d):
 
     def integrator(self, q, etype='cell'):
         """
-        @brief 获取不同维度网格实体上的积分公式 
+        @brief 获取不同维度网格实体上的积分公式
         """
         if etype in {'cell', 2}:
             return TriangleQuadrature(q)
@@ -77,7 +77,7 @@ class TriangleMesh(Mesh2d):
         entity = self.entity(etype=TD)[index]
         p = np.einsum('...j, ijk->...ik', bc, node[entity])
         return p
-    
+
     def point_to_bc(self, point):
         i_cell = self.location(point)
         node = self.node
@@ -115,9 +115,9 @@ class TriangleMesh(Mesh2d):
 
     def shape_function(self, bc, p=1):
         """
-        @brief 
+        @brief
         """
-        TD = bc.shape[-1] - 1 
+        TD = bc.shape[-1] - 1
         multiIndex = self.multi_index_matrix(p)
         c = np.arange(1, p+1, dtype=np.int_)
         P = 1.0/np.multiply.accumulate(c)
@@ -265,7 +265,7 @@ class TriangleMesh(Mesh2d):
         """
         @brief 获取三角形上的 p 次的多重指标矩阵
 
-        @param[in] p positive integer 
+        @param[in] p positive integer
 
         @return multiIndex  ndarray with shape (ldof, 3)
         """
@@ -287,18 +287,18 @@ class TriangleMesh(Mesh2d):
 
     def number_of_local_ipoints(self, p, iptype='cell'):
         if iptype in {'cell', 2}:
-            return (p+1)*(p+2)//2 
+            return (p+1)*(p+2)//2
         elif iptype in {'face', 'edge',  1}:
             return self.p + 1
         elif iptype in {'node', 0}:
             return 1
-    
+
     def number_of_global_ipoints(self, p):
         NN = self.number_of_nodes()
         NE = self.number_of_edges()
         NC = self.number_of_cells()
         return NN + (p-1)*NE + (p-2)*(p-1)/2*NC
-    
+
     def interpolation_points(self, p):
         """
         @brief 获取三角形网格上所有 p 次插值点
@@ -308,7 +308,7 @@ class TriangleMesh(Mesh2d):
         if p == 1:
             return node
         if p > 1:
-            NN = self.number_of_nodes() 
+            NN = self.number_of_nodes()
             GD = self.geo_dimension()
 
             gdof = self.number_of_global_ipoints(p)
@@ -333,11 +333,11 @@ class TriangleMesh(Mesh2d):
             ipoints[NN+(p-1)*NE:, :] = np.einsum('ij, kj...->ki...', w,
                     node[cell, :]).reshape(-1, GD)
         return ipoints
-    
-    
+
+
     def edge_to_ipoint(self, p):
         """
-        @brief 获取网格边与插值点的对应关系 
+        @brief 获取网格边与插值点的对应关系
         """
         NE = self.number_of_edges()
         NN = self.number_of_nodes()
@@ -348,10 +348,10 @@ class TriangleMesh(Mesh2d):
         if p > 1:
             edge2ipoints[:, 1:-1] = NN + np.arange(NE*(p-1)).reshape(NE, p-1)
         return edge2ipoints
-    
+
     def cell_to_ipoint(self, p):
         """
-        @brief 获取网格中的三角形单元与插值点的对应关系 
+        @brief 获取网格中的三角形单元与插值点的对应关系
         """
         cell = self.entity('cell')
         NN = self.number_of_nodes()
@@ -368,7 +368,7 @@ class TriangleMesh(Mesh2d):
 
             isEdgeIPoint = self.multi_index_matrix(p, 'cell') == 0
             edge2ipoint = self.edge_to_ipoint(p)
-            
+
 
             cell2edgeSign = self.ds.cell_to_edge_sign()
             cell2edge = self.ds.cell_to_edge()
@@ -423,7 +423,7 @@ class TriangleMesh(Mesh2d):
 
         NC = len(cell)
         if fname is None:
-            return node, cell.flatten(), cellType, NC 
+            return node, cell.flatten(), cellType, NC
         else:
             print("Writting to vtk...")
             write_to_vtu(fname, node, NC, cellType, cell.flatten(),
@@ -529,7 +529,7 @@ class TriangleMesh(Mesh2d):
         isNotOK = np.ones(len(segment), dtype=np.bool_)
         jdx = 3
         while isNotOK.any():
-            idx = start[isNotOK] # 当前单元 
+            idx = start[isNotOK] # 当前单元
 
             pp0 = p0[isNotOK]
             pp1 = p1[isNotOK]
@@ -565,7 +565,7 @@ class TriangleMesh(Mesh2d):
             # 移动到下一个单元
             tmp = start[idx0[~isOK]]
             start[idx0[~isOK]] = cell2cell[idx[~isOK], lidx[~isOK]]
-            isNotOK[idx0[isOK]] = False 
+            isNotOK[idx0[isOK]] = False
             _, jdx = np.where((cell2cell[start[isNotOK]].T==tmp).T)
 
             # 这些单元标记为穿过单元
@@ -624,23 +624,23 @@ class TriangleMesh(Mesh2d):
             pp = points[isNotOK]
 
             v0 = node[cell[idx, 0]] - pp # 所在单元的三个顶点
-            v1 = node[cell[idx, 1]] - pp 
+            v1 = node[cell[idx, 1]] - pp
             v2 = node[cell[idx, 2]] - pp
 
             a = np.zeros((len(idx), 3), dtype=self.ftype)
             a[:, 0] = np.cross(v1, v2)
             a[:, 1] = np.cross(v2, v0)
             a[:, 2] = np.cross(v0, v1)
-            lidx = np.argmin(a, axis=-1) 
+            lidx = np.argmin(a, axis=-1)
 
             # 最小面积小于 0, 说明点在单元外
-            isOutCell = a[range(a.shape[0]), lidx] < 0.0 
+            isOutCell = a[range(a.shape[0]), lidx] < 0.0
 
             idx0, = np.nonzero(isNotOK)
             start[idx0[isOutCell]] = cell2cell[idx[isOutCell], lidx[isOutCell]]
             isNotOK[idx0[~isOutCell]] = False
 
-        return start 
+        return start
 
     def circumcenter(self, index=np.s_[:], returnradius=False):
         """
@@ -705,7 +705,7 @@ class TriangleMesh(Mesh2d):
             isNonDelaunayEdge = (asum > np.pi) & (edge2cell[:,0] != edge2cell[:,1])
 
             return isNonDelaunayEdge
-            
+
             if np.sum(isNonDelaunayEdge) == 0:
                 break
             # Find dependent set of swap edges
@@ -721,7 +721,7 @@ class TriangleMesh(Mesh2d):
                 pnext = np.array([1, 2, 0])
                 idx = edge2cell[isNonDelaunayEdge, 2]
                 p0 = cell[edge2cell[isNonDelaunayEdge, 0], idx]
-                p1 = cell[edge2cell[isNonDelaunayEdge, 0], pnext[idx]] 
+                p1 = cell[edge2cell[isNonDelaunayEdge, 0], pnext[idx]]
                 idx = edge2cell[isNonDelaunayEdge, 3]
                 p2 = cell[edge2cell[isNonDelaunayEdge, 1], idx]
                 p3 = cell[edge2cell[isNonDelaunayEdge, 1], pnext[idx]]
@@ -758,7 +758,7 @@ class TriangleMesh(Mesh2d):
         return options
 
     def bisect(self, isMarkedCell=None, options={'disp':True}):
-        
+
         if options['disp']:
             print('Bisection begining......')
 
@@ -865,10 +865,10 @@ class TriangleMesh(Mesh2d):
                         bcr[:, 2] = 1/2*bc[:, 0] + bc[:, 1]
 
                         value = np.r_['0', value, np.zeros((nc, ldof), dtype=self.ftype)]
-                        
+
                         phi = self.shape_function(bcr, p=p)
                         value[NC:, :] = np.einsum('cj,kj->ck', value[idx], phi)
-                        
+
                         phi = self.shape_function(bcl, p=p)
                         value[idx, :] = np.einsum('cj,kj->ck', value[idx], phi)
 
@@ -899,7 +899,7 @@ class TriangleMesh(Mesh2d):
 
     def coarsen(self, isMarkedCell=None, options={}):
         """
-        @brief 
+        @brief
 
         https://lyc102.github.io/ifem/afem/coarsen/
         """
@@ -907,7 +907,7 @@ class TriangleMesh(Mesh2d):
         if isMarkedCell is None:
             return
 
-        
+
         NN = self.number_of_nodes()
         NC = self.number_of_cells()
 
@@ -973,24 +973,24 @@ class TriangleMesh(Mesh2d):
         if ('data' in options) and (options['data'] is not None):
             # value.shape == (NC, (p+1)*(p+2)//2)
             lidx = np.r_[t0, t2, t4]
-            ridx = np.r_[t1, t3, t5] 
+            ridx = np.r_[t1, t3, t5]
             for key, value in options['data'].items():
                 ldof = value.shape[1]
                 p = int((np.sqrt(8*ldof+1) - 3)/2)
                 bc = self.multi_index_matrix(p=p)/p
                 bcl = np.zeros_like(bc)
-                bcl[:, 0] = 2*bc[:, 2] 
-                bcl[:, 1] = bc[:, 0] 
-                bcl[:, 2] = bc[:, 1] - bc[:, 2] 
+                bcl[:, 0] = 2*bc[:, 2]
+                bcl[:, 1] = bc[:, 0]
+                bcl[:, 2] = bc[:, 1] - bc[:, 2]
 
                 bcr = np.zeros_like(bc)
-                bcr[:, 0] = 2*bc[:, 1] 
-                bcr[:, 1] = bc[:, 2] - bc[:, 1] 
-                bcr[:, 2] = bc[:, 0] 
-                
+                bcr[:, 0] = 2*bc[:, 1]
+                bcr[:, 1] = bc[:, 2] - bc[:, 1]
+                bcr[:, 2] = bc[:, 0]
+
                 phi = self.shape_function(bcl, p=p) # (NQ, ldof)
-                value[lidx, :] = np.einsum('ci, qi->cq', value[lidx, :], phi) 
-                
+                value[lidx, :] = np.einsum('ci, qi->cq', value[lidx, :], phi)
+
                 phi = self.shape_function(bcr, p=p) # (NQ, ldof)
                 value[lidx, :]+= np.einsum('ci, qi->cq', value[ridx, :], phi)
                 value[lidx] /= 2
@@ -1166,7 +1166,7 @@ class TriangleMesh(Mesh2d):
 
         # 当前的二分边的数目
         nCut = 0
-        # 非协调边的标记数组 
+        # 非协调边的标记数组
         nonConforming = np.ones(4*NN, dtype=np.bool_)
         while len(markedCell) != 0:
             # 标记最长边
@@ -1177,11 +1177,11 @@ class TriangleMesh(Mesh2d):
             p1 = cell[markedCell, 1]
             p2 = cell[markedCell, 2]
 
-            # 找到新的二分边和新的中点 
+            # 找到新的二分边和新的中点
             nMarked = len(markedCell)
             p3 = np.zeros(nMarked, dtype=self.itype)
 
-            if nCut == 0: # 如果是第一次循环 
+            if nCut == 0: # 如果是第一次循环
                 idx = np.arange(nMarked) # cells introduce new cut edges
             else:
                 # all non-conforming edges
@@ -1198,7 +1198,7 @@ class TriangleMesh(Mesh2d):
                 idx, = np.nonzero(p3 == 0)
 
             if len(idx) != 0:
-                # 把需要二分的边唯一化 
+                # 把需要二分的边唯一化
                 NE = len(idx)
                 cellCutEdge = np.array([p1[idx], p2[idx]])
                 cellCutEdge.sort(axis=0)
@@ -1210,7 +1210,7 @@ class TriangleMesh(Mesh2d):
                             cellCutEdge[1, :]
                         )
                     ), shape=(NN, NN))
-                # 获得唯一的边 
+                # 获得唯一的边
                 i, j = s.nonzero()
                 nNew = len(i)
                 newCutEdge = np.arange(nCut, nCut+nNew)
@@ -1221,7 +1221,7 @@ class TriangleMesh(Mesh2d):
                 nCut += nNew
                 NN += nNew
 
-                # 新点和旧点的邻接矩阵 
+                # 新点和旧点的邻接矩阵
                 I = cutEdge[newCutEdge][:, [2, 2]].reshape(-1)
                 J = cutEdge[newCutEdge][:, [0, 1]].reshape(-1)
                 val = np.ones(len(I), dtype=np.bool_)
@@ -1236,7 +1236,7 @@ class TriangleMesh(Mesh2d):
             cellGeneration = np.max(
                     generation[cell[markedCell[idx]]],
                     axis=-1)
-            # 第几代点 
+            # 第几代点
             generation[p3[idx]] = cellGeneration + 1
             cell[markedCell, 0] = p3
             cell[markedCell, 1] = p0
@@ -1252,14 +1252,14 @@ class TriangleMesh(Mesh2d):
             NC = NC + nMarked
             del cellGeneration, p0, p1, p2, p3
 
-            # 找到非协调的单元 
+            # 找到非协调的单元
             checkEdge, = np.nonzero(nonConforming[:nCut])
             isCheckNode = np.zeros(NN, dtype=np.bool_)
             isCheckNode[cutEdge[checkEdge]] = True
             isCheckCell = np.sum(
                     isCheckNode[cell[:NC]],
                     axis= -1) > 0
-            # 找到所有包含检查节点的单元编号 
+            # 找到所有包含检查节点的单元编号
             checkCell, = np.nonzero(isCheckCell)
             I = np.repeat(checkCell, 3)
             J = cell[checkCell].reshape(-1)
@@ -1337,13 +1337,13 @@ class TriangleMesh(Mesh2d):
         gphi = self.grad_lambda()
 
         if callable(c):
-            bc = np.array([1/3, 1/3, 1/3], dtype=self.ftype) 
+            bc = np.array([1/3, 1/3, 1/3], dtype=self.ftype)
             if c.coordtype == 'cartesian':
                 ps = self.bc_to_point(bc)
                 c = c(ps)
             elif c.coordtype == 'barycentric':
                 c = c(bc)
-        
+
         if c is not None:
             area *= c
 
@@ -1413,7 +1413,7 @@ class TriangleMesh(Mesh2d):
 
     def mark_interface_cell_with_curvature(self, phi, hmax=None):
         """
-        @brief 标记曲率大的单元 
+        @brief 标记曲率大的单元
         """
 
         if callable(phi):
@@ -1431,11 +1431,11 @@ class TriangleMesh(Mesh2d):
         isInterfaceCell = self.mark_interface_cell(phi)
         isInterfaceNode = np.zeros(NN, dtype=np.bool_)
         # 界面单元的顶点称为界面节点
-        isInterfaceNode[cell[isInterfaceCell]] = True 
+        isInterfaceNode[cell[isInterfaceCell]] = True
 
         # case: Fig 2(a) in p6
         # 一个网格点周围的单元全为界面单元，则周围这些单元以该网格节点为顶点的角度
-        # 之和为 360 
+        # 之和为 360
         angle = np.zeros(NN, dtype=self.itype)
         np.add.at(angle, cell[isInterfaceCell, :], np.array([90, 45, 45]))
         is360 = (angle == 360)
@@ -1443,7 +1443,7 @@ class TriangleMesh(Mesh2d):
 
         # case: Fig 2(b) in p6
         isInteriorEdge = ~self.ds.boundary_edge_flag()
-        isInterfaceBEdge = (isInterfaceCell[edge2cell[:, 0:2]].sum(axis=1) == 1) 
+        isInterfaceBEdge = (isInterfaceCell[edge2cell[:, 0:2]].sum(axis=1) == 1)
         valence = np.zeros(NN, dtype=self.itype)
         if np.any(isInterfaceBEdge):
             np.add.at(valence, edge[isInterfaceBEdge], 1)
@@ -1467,7 +1467,7 @@ class TriangleMesh(Mesh2d):
         ta = tangle[edge[isInterfaceEdge][:, 1::-1]]
         np.add.at(tangle, edge[isInterfaceEdge], ta)
 
-        
+
         flag = np.abs(tangle) > 170
         print("转角:", flag.sum())
 
@@ -1477,7 +1477,7 @@ class TriangleMesh(Mesh2d):
 
         v = node[cell[:, 2]] - node[cell[:, 1]]
         l = np.sqrt(np.sum(v**2, axis=1))
-        if hmax is None: 
+        if hmax is None:
             lmax = np.max(l)
             isBigSizeCell = (l > lmax*lmax) & isInterfaceCell
         else:
@@ -1535,7 +1535,7 @@ class TriangleMesh(Mesh2d):
             isTransitionTypeBCell[idx[isNotTB]] = False
 
         # Case 2:
-        n2 = cell2cell[:, 2] 
+        n2 = cell2cell[:, 2]
         flag = isTransitionTypeBCell & isInterfaceCell[n2] & cellType[n2]
         if np.any(flag):
             idx, = np.nonzero(flag)
@@ -1567,7 +1567,7 @@ class TriangleMesh(Mesh2d):
             isTransitionTypeBCell[idx[isNotTB]] = False
 
         # Case 4:
-        n2 = cell2cell[:, 2] 
+        n2 = cell2cell[:, 2]
         flag = isTransitionTypeBCell & isInterfaceCell[n2] & (~cellType[n2])
         if np.any(flag):
             idx, = np.nonzero(flag)
@@ -1579,7 +1579,7 @@ class TriangleMesh(Mesh2d):
             isNotTB = interface(m0)*interface(m1) < 0.0
             isTransitionTypeBCell[idx[isNotTB]] = False
 
-        
+
         isTypeBCell = isMark & (~cellType) & (~isTransitionTypeBCell)
         return isTypeBCell, cellType
 
@@ -1632,12 +1632,12 @@ class TriangleMesh(Mesh2d):
     def from_unit_square(cls, nx=10, ny=10, threshold=None):
         """
         Generate a triangle mesh for a unit square.
-        
+
         @param nx Number of divisions along the x-axis (default: 10)
         @param ny Number of divisions along the y-axis (default: 10)
         @param threshold Optional function to filter cells based on their barycenter coordinates (default: None)
         @return TriangleMesh instance
-        """ 
+        """
         return cls.from_box(box=[0, 1, 0, 1], nx=nx, ny=ny, threshold=threshold)
 
     ## @ingroup MeshGenerators
@@ -1645,18 +1645,18 @@ class TriangleMesh(Mesh2d):
     def from_box(cls, box=[0, 1, 0, 1], nx=10, ny=10, threshold=None):
         """
         Generate a triangle mesh for a box domain .
-        
-        @param box 
+
+        @param box
         @param nx Number of divisions along the x-axis (default: 10)
         @param ny Number of divisions along the y-axis (default: 10)
         @param threshold Optional function to filter cells based on their barycenter coordinates (default: None)
         @return TriangleMesh instance
-        """ 
+        """
         NN = (nx+1)*(ny+1)
         NC = nx*ny
         node = np.zeros((NN,2))
         X, Y = np.mgrid[
-                box[0]:box[1]:(nx+1)*1j, 
+                box[0]:box[1]:(nx+1)*1j,
                 box[2]:box[3]:(ny+1)*1j]
         node[:, 0] = X.flat
         node[:, 1] = Y.flat
@@ -1672,7 +1672,7 @@ class TriangleMesh(Mesh2d):
 
         if threshold is not None:
             bc = np.sum(node[cell, :], axis=1)/cell.shape[1]
-            isDelCell = threshold(bc) 
+            isDelCell = threshold(bc)
             cell = cell[~isDelCell]
             isValidNode = np.zeros(NN, dtype=np.bool_)
             isValidNode[cell] = True
@@ -1735,6 +1735,7 @@ class TriangleMesh(Mesh2d):
         @param h Parameter controlling mesh density
         @return TriangleMesh instance
         """
+        import gmsh
         gmsh.initialize()
         gmsh.model.add("UnitCircle")
 
@@ -1766,7 +1767,7 @@ class TriangleMesh(Mesh2d):
         # 获取三角形单元信息
         cell_type = 2  # 三角形单元的类型编号为 2
         cell_tags, cell_connectivity = gmsh.model.mesh.getElementsByType(cell_type)
-        cell = np.array(tri_connectivity, dtype=np.uint64).reshape(-1, 3) - 1
+        cell = np.array(cell_connectivity, dtype=np.uint64).reshape(-1, 3) - 1
 
         # 输出节点和单元数量
         print(f"Number of nodes: {node.shape[0]}")
@@ -1853,7 +1854,7 @@ class TriangleMesh(Mesh2d):
         idxMap = np.zeros(NN, dtype=cell.dtype)
         idxMap[isValidNode] = range(isValidNode.sum())
         cell = idxMap[cell]
-    
+
         return cls(node, cell)
 
     ## @ingroup MeshGenerators
@@ -1984,7 +1985,7 @@ class TriangleMeshWithInfinityNode:
         NV = np.asarray((node2cell > 0).sum(axis=1)).reshape(-1)
         NV[isBdNode] += 1
         NV = NV[:-1]
-        
+
         PNC = len(NV)
         pcell = np.zeros(NV.sum(), dtype=self.itype)
         pcellLocation = np.zeros(PNC+1, dtype=self.itype)
@@ -1998,7 +1999,7 @@ class TriangleMeshWithInfinityNode:
         currentCellIdx[cell[:NC, 0]] = range(NC)
         currentCellIdx[cell[:NC, 1]] = range(NC)
         currentCellIdx[cell[:NC, 2]] = range(NC)
-        pcell[pcellLocation[:-1]] = currentCellIdx 
+        pcell[pcellLocation[:-1]] = currentCellIdx
 
         currentIdx = pcellLocation[:-1]
         N = self.number_of_nodes() - 1
@@ -2025,4 +2026,3 @@ class TriangleMeshWithInfinityNode:
             currentIdx += 1
 
         return pnode, pcell, pcellLocation
-

--- a/fealpy/mesh/UniformMesh2d.py
+++ b/fealpy/mesh/UniformMesh2d.py
@@ -10,14 +10,14 @@ from .Mesh2d import Mesh2d
 from .StructureMesh2dDataStructure import StructureMesh2dDataStructure
 from ..geometry import project
 
-## @defgroup FEMInterface                                                                                                                                            
+## @defgroup FEMInterface
 ## @defgroup FDMInterface
 ## @defgroup GeneralInterface
 class UniformMesh2d(Mesh2d):
     """
     @brief A class for representing a two-dimensional structured mesh with uniform discretization in both x and y directions.
     """
-    def __init__(self, 
+    def __init__(self,
             extent: Tuple[int, int, int, int],
             h: Tuple[float, float] = (1.0, 1.0),
             origin: Tuple[float, float] = (0.0, 0.0),
@@ -83,7 +83,7 @@ class UniformMesh2d(Mesh2d):
         """
         @brief Get the number of edges in the mesh.
 
-        @note `edge` is the 1D entity 
+        @note `edge` is the 1D entity
 
         @return The number of edges.
         """
@@ -94,7 +94,7 @@ class UniformMesh2d(Mesh2d):
         """
         @brief Get the number of faces in the mesh.
 
-        @note `face` is the 1D entity 
+        @note `face` is the 1D entity
 
         @return The number of faces.
         """
@@ -123,7 +123,7 @@ class UniformMesh2d(Mesh2d):
                  For each iteration, it updates the mesh extent, step size, number of cells, and number of nodes,
                  as well as the data structure. If returnim is True, it also calculates and returns the
                  interpolation matrices for each iteration.
-        
+
         """
         for i in range(n):
             self.extent = [i * 2 for i in self.extent]
@@ -147,7 +147,7 @@ class UniformMesh2d(Mesh2d):
         """
         @brief 返回边长，注意这里返回两个值，一个 x 方向，一个 y 方向
         """
-        return self.h[0], sef.h[1]
+        return self.h[0], self.h[1]
 
     ## @ingroup GeneralInterface
     def cell_location(self, p):
@@ -197,8 +197,8 @@ class UniformMesh2d(Mesh2d):
             axes.set_title(s)
             axes.set_aspect('equal')
             #fig.colorbar(data)
-            return data 
-       
+            return data
+
         ani = animation.FuncAnimation(fig, func, frames=frames, interval=interval)
         ani.save(fname)
 
@@ -251,9 +251,9 @@ class UniformMesh2d(Mesh2d):
 
         nx = self.ds.nx
         ny = self.ds.ny
-        box = [self.origin[0], self.origin[0] + nx*self.h[0], 
+        box = [self.origin[0], self.origin[0] + nx*self.h[0],
                self.origin[1], self.origin[1] + ny*self.h[1]]
-	
+
         x = np.linspace(box[0], box[1], nx+1)
         y = np.linspace(box[2], box[3], ny+1)
         z = np.zeros(1)
@@ -283,7 +283,7 @@ class UniformMesh2d(Mesh2d):
         node[..., 0], node[..., 1] = np.mgrid[
                                      box[0]:box[1]:(nx + 1)*1j,
                                      box[2]:box[3]:(ny + 1)*1j]
-        return node 
+        return node
 
     ## @ingroup FDMInterface
     def cell_barycenter(self):
@@ -293,7 +293,7 @@ class UniformMesh2d(Mesh2d):
         GD = self.geo_dimension()
         nx = self.nx
         ny = self.ny
-        box = [self.origin[0] + self.h[0]/2, self.origin[0] + self.h[0]/2 + (nx-1)*self.h[0], 
+        box = [self.origin[0] + self.h[0]/2, self.origin[0] + self.h[0]/2 + (nx-1)*self.h[0],
                self.origin[1] + self.h[1]/2, self.origin[1] + self.h[1]/2 + (ny-1)*self.h[1]]
         bc = np.zeros((nx, ny, 2), dtype=self.ftype)
         bc[..., 0], bc[..., 1] = np.mgrid[
@@ -381,7 +381,7 @@ class UniformMesh2d(Mesh2d):
         elif etype in {'cell', 2}:
             uh = np.zeros((nx+2*ex, ny+2*ex), dtype=dtype)
         else:
-            raise ValueError(f'the entity `{entity}` is not correct!') 
+            raise ValueError(f'the entity `{etype}` is not correct!')
 
         return uh
 
@@ -394,7 +394,7 @@ class UniformMesh2d(Mesh2d):
         hy = self.h[1]
         fx, fy = np.gradient(f, hx, hy, edge_order=order)
         return fx, fy
-        
+
     ## @ingroup FDMInterface
     def divergence(self, f_x, f_y, order=1):
         """
@@ -405,7 +405,7 @@ class UniformMesh2d(Mesh2d):
         hy = self.h[1]
         f_xx,f_xy = np.gradient(f_x, hx, edge_order=order)
         f_yx,f_yy = np.gradient(f_y, hy, edge_order=order)
-        return fxx + fyy
+        return f_xx + f_yy
 
     ## @ingroup FDMInterface
     def laplace(self, f, order=1):
@@ -414,7 +414,7 @@ class UniformMesh2d(Mesh2d):
         fx, fy = np.gradient(f, hx, hy, edge_order=order)
         fxx,fxy = np.gradient(fx, hx, edge_order=order)
         fyx,fyy = np.gradient(fy, hy, edge_order=order)
-        return fxx + fyy 
+        return fxx + fyy
 
     ## @ingroup FDMInterface
     def value(self, p, f):
@@ -443,7 +443,7 @@ class UniformMesh2d(Mesh2d):
         a = (p[..., 0] - x0) / hx
         b = (p[..., 1] - y0) / hy
         F = f[i, j] * (1-a) * (1-b)  + f[i + 1, j] * a * (1-b) \
-            + f[i, j + 1] * (1-a) * b + f[i + 1, j + 1] * a * b 
+            + f[i, j + 1] * (1-a) * b + f[i + 1, j + 1] * a * b
         return F
 
     ## @ingroup FDMInterface
@@ -527,7 +527,7 @@ class UniformMesh2d(Mesh2d):
         @brief Assemble the finite difference matrix for a general elliptic operator.
         """
         pass
-   
+
     ## @ingroup FDMInterface
     def laplace_operator(self):
         """
@@ -589,9 +589,9 @@ class UniformMesh2d(Mesh2d):
 
         nx = self.ds.nx
         ny = self.ds.ny
-        box = [self.origin[0], self.origin[0] + nx*self.h[0], 
+        box = [self.origin[0], self.origin[0] + nx*self.h[0],
                self.origin[1], self.origin[1] + ny*self.h[1]]
-	
+
         x = np.linspace(box[0], box[1], nx+1)
         y = np.linspace(box[2], box[3], ny+1)
         z = np.zeros(1)
@@ -600,85 +600,85 @@ class UniformMesh2d(Mesh2d):
         return filename
 
     def fast_sweeping_method(self, phi0):
-    	"""
+        """
         @brief 均匀网格上的 fast sweeping method
         @param[in] phi 是一个离散的水平集函数
 
         @note 注意，我们这里假设 x 和 y 方向剖分的段数相等
-    	"""
-    	m = 2
-    	nx = self.ds.nx
-    	ny = self.ds.ny
-    	k = nx/ny
-    	ns = ny
-    	h = self.h[0]
-    	
-    	phi = self.function(ex=1)
-    	isNearNode = self.function(dtype=np.bool_, ex=1)
-    	
-    	# 把水平集函数转化为离散的网格函数
-    	node = self.entity('node')
-    	phi[1:-1, 1:-1] = phi0
-    	sign = np.sign(phi[1:-1, 1:-1])
-    	
-    	# 标记界面附近的点
-    	isNearNode[1:-1, 1:-1] = np.abs(phi[1:-1, 1:-1]) < 2*h
-    	lsfun = UniformMesh2dFunction(self, phi[1:-1, 1:-1])
-    	_, d = lsfun.project(node[isNearNode[1:-1, 1:-1]])
-    	phi[isNearNode] = np.abs(d) #界面附近的点用精确值
-    	phi[~isNearNode] = m  # 其它点用一个比较大的值
-    	
-    	a = np.zeros(ns+1, dtype=np.float64)
-    	b = np.zeros(ns+1, dtype=np.float64)
-    	c = np.zeros(ns+1, dtype=np.float64)
-    	d = np.zeros(int(k*ns+1), dtype=np.float64)
-    	e = np.zeros(int(k*ns+1), dtype=np.float64)
-    	f = np.zeros(int(k*ns+1), dtype=np.float64)
-    	
-    	n = 0
-    	for i in range(1, int(k*ns+2)):
-    	    a[:] = np.minimum(phi[i-1, 1:-1], phi[i+1, 1:-1])
-    	    b[:] = np.minimum(phi[i, 0:ns+1], phi[i, 2:])
-    	    flag = np.abs(a-b) >= h
-    	    c[flag] = np.minimum(a[flag], b[flag]) + h
-    	    c[~flag] = (a[~flag] + b[~flag] + np.sqrt(2*h*h - (a[~flag] - b[~flag])**2))/2
-    	    phi[i, 1:-1] = np.minimum(c, phi[i, 1:-1])
-    	    n += 1
-    	    
-    	for i in range(int(k*ns+1), 0, -1):
-    	    a[:] = np.minimum(phi[i-1, 1:-1], phi[i+1, 1:-1])
-    	    b[:] = np.minimum(phi[i, 0:ns+1], phi[i, 2:])
-    	    flag = np.abs(a-b) >= h 
-    	    c[flag] = np.minimum(a[flag], b[flag]) + h
-    	    c[~flag] = (a[~flag] + b[~flag] + np.sqrt(2*h*h - (a[~flag] - b[~flag])**2))/2
-    	    phi[i, 1:-1] = np.minimum(c, phi[i, 1:-1])
-    	    n += 1
-    	    
-    	for j in range(1, ns+2):
-    	    d[:] = np.minimum(phi[0:int(k*ns+1), j], phi[2:, j])
-    	    e[:] = np.minimum(phi[1:-1, j-1], phi[1:-1, j+1])
-    	    flag = np.abs(d-e) >= h 
-    	    f[flag] = np.minimum(d[flag], e[flag]) + h
-    	    f[~flag] = (d[~flag] + e[~flag] + np.sqrt(2*h*h - (d[~flag] - e[~flag])**2))/2
-    	    phi[1:-1, j] = np.minimum(f, phi[1:-1, j])
-    	    n += 1
-    	    
-    	for j in range(ns+1, 0, -1):
-    	    d[:] = np.minimum(phi[0:int(k*ns+1), j], phi[2:, j])
-    	    e[:] = np.minimum(phi[1:-1, j-1], phi[1:-1, j+1])
-    	    flag = np.abs(d-e) >= h
-    	    f[flag] = np.minimum(d[flag], e[flag]) + h
-    	    f[~flag] = (d[~flag] + e[~flag] + np.sqrt(2*h*h - (d[~flag] - e[~flag])**2))/2
-    	    phi[1:-1, j] = np.minimum(f, phi[1:-1, j])
-    	    n += 1
-    	    
-    	return sign*phi[1:-1, 1:-1]
+        """
+        m = 2
+        nx = self.ds.nx
+        ny = self.ds.ny
+        k = nx/ny
+        ns = ny
+        h = self.h[0]
+
+        phi = self.function(ex=1)
+        isNearNode = self.function(dtype=np.bool_, ex=1)
+
+        # 把水平集函数转化为离散的网格函数
+        node = self.entity('node')
+        phi[1:-1, 1:-1] = phi0
+        sign = np.sign(phi[1:-1, 1:-1])
+
+        # 标记界面附近的点
+        isNearNode[1:-1, 1:-1] = np.abs(phi[1:-1, 1:-1]) < 2*h
+        lsfun = UniformMesh2dFunction(self, phi[1:-1, 1:-1])
+        _, d = lsfun.project(node[isNearNode[1:-1, 1:-1]])
+        phi[isNearNode] = np.abs(d) #界面附近的点用精确值
+        phi[~isNearNode] = m  # 其它点用一个比较大的值
+
+        a = np.zeros(ns+1, dtype=np.float64)
+        b = np.zeros(ns+1, dtype=np.float64)
+        c = np.zeros(ns+1, dtype=np.float64)
+        d = np.zeros(int(k*ns+1), dtype=np.float64)
+        e = np.zeros(int(k*ns+1), dtype=np.float64)
+        f = np.zeros(int(k*ns+1), dtype=np.float64)
+
+        n = 0
+        for i in range(1, int(k*ns+2)):
+            a[:] = np.minimum(phi[i-1, 1:-1], phi[i+1, 1:-1])
+            b[:] = np.minimum(phi[i, 0:ns+1], phi[i, 2:])
+            flag = np.abs(a-b) >= h
+            c[flag] = np.minimum(a[flag], b[flag]) + h
+            c[~flag] = (a[~flag] + b[~flag] + np.sqrt(2*h*h - (a[~flag] - b[~flag])**2))/2
+            phi[i, 1:-1] = np.minimum(c, phi[i, 1:-1])
+            n += 1
+
+        for i in range(int(k*ns+1), 0, -1):
+            a[:] = np.minimum(phi[i-1, 1:-1], phi[i+1, 1:-1])
+            b[:] = np.minimum(phi[i, 0:ns+1], phi[i, 2:])
+            flag = np.abs(a-b) >= h
+            c[flag] = np.minimum(a[flag], b[flag]) + h
+            c[~flag] = (a[~flag] + b[~flag] + np.sqrt(2*h*h - (a[~flag] - b[~flag])**2))/2
+            phi[i, 1:-1] = np.minimum(c, phi[i, 1:-1])
+            n += 1
+
+        for j in range(1, ns+2):
+            d[:] = np.minimum(phi[0:int(k*ns+1), j], phi[2:, j])
+            e[:] = np.minimum(phi[1:-1, j-1], phi[1:-1, j+1])
+            flag = np.abs(d-e) >= h
+            f[flag] = np.minimum(d[flag], e[flag]) + h
+            f[~flag] = (d[~flag] + e[~flag] + np.sqrt(2*h*h - (d[~flag] - e[~flag])**2))/2
+            phi[1:-1, j] = np.minimum(f, phi[1:-1, j])
+            n += 1
+
+        for j in range(ns+1, 0, -1):
+            d[:] = np.minimum(phi[0:int(k*ns+1), j], phi[2:, j])
+            e[:] = np.minimum(phi[1:-1, j-1], phi[1:-1, j+1])
+            flag = np.abs(d-e) >= h
+            f[flag] = np.minimum(d[flag], e[flag]) + h
+            f[~flag] = (d[~flag] + e[~flag] + np.sqrt(2*h*h - (d[~flag] - e[~flag])**2))/2
+            phi[1:-1, j] = np.minimum(f, phi[1:-1, j])
+            n += 1
+
+        return sign*phi[1:-1, 1:-1]
 
     ## @ingroup FEMInterface
     def geo_dimension(self):
         """
         @brief Get the geometry dimension of the mesh.
-        
+
         @return The geometry dimension (2 for 2D mesh).
         """
         return 2
@@ -687,7 +687,7 @@ class UniformMesh2d(Mesh2d):
     def top_dimension(self):
         """
         @brief Get the topological dimension of the mesh.
-        
+
         @return The topological dimension (2 for 2D mesh).
         """
         return 2
@@ -700,7 +700,7 @@ class UniformMesh2d(Mesh2d):
     def bc_to_point(self, bc, index=np.s_[:]):
         pass
 
-    ## @ingroup FEMInterface 
+    ## @ingroup FEMInterface
     def entity(self, etype):
         """
         @brief Get the entity (either cell or node) based on the given entity type.
@@ -716,11 +716,11 @@ class UniformMesh2d(Mesh2d):
         elif etype in {'edge', 'face', 1}:
             return self.ds.edge
         elif etype in {'node', 0}:
-            return self.node.reshape(-1, 2) 
+            return self.node.reshape(-1, 2)
         else:
             raise ValueError("`etype` is wrong!")
 
-    ## @ingroup FEMInterface 
+    ## @ingroup FEMInterface
     def entity_barycenter(self, etype):
         """
         @brief Get the entity (cell, {face, edge}, or  node) based on the given entity type.
@@ -736,7 +736,7 @@ class UniformMesh2d(Mesh2d):
             return self.cell_barycenter().reshape(-1, 2)
         elif etype in {'edge', 'face', 1}:
             bcx, bcy = self.edge_barycenter()
-            return np.concatenate((bcx.reshape(-1, 2), bcy.reshape(-1, 2)), axis=0) 
+            return np.concatenate((bcx.reshape(-1, 2), bcy.reshape(-1, 2)), axis=0)
         elif etype in {'node', 0}:
             return self.node.reshape(-1, 2)
         else:
@@ -764,7 +764,7 @@ class UniformMesh2d(Mesh2d):
     ## @ingroup FEMInterface
     def number_of_local_ipoints(self, p, iptype='cell'):
         pass
-    
+
     ## @ingroup FEMInterface
     def number_of_global_ipoints(self, p):
         pass
@@ -808,28 +808,28 @@ class UniformMesh2d(Mesh2d):
         return idx
 
     def  s2tidx(self):
-    	"""
-    	@brief 已知结构四边形网格点的值，将其排列到结构三角形网格上
-    	@example a[s2tidx] = uh
-    	"""
-    	tnx = int(self.ds.nx/2)
-    	tny = int(self.ds.ny/2)
-    	a = np.arange(tny+1)
-    	b = 3*np.arange(tny).reshape(-1,1)+(tnx+1)*(tny+1)
-    	idx1 = np.zeros((tnx+1,2*tny+1))#sny+1
-    	idx1[:,0::2] = a+np.arange(tnx+1).reshape(-1,1)*(tny+1)
-    	idx1[:,1::2] = b.flatten()+np.arange(tnx+1).reshape(-1,1)*(2*tny+1+tny)
-    	idx1[-1,1::2] = np.arange((2*tnx+1)*(2*tny+1)-tny,(2*tnx+1)*(2*tny+1))
-    	c = np.array([(tnx+1)*(tny+1)+1,(tnx+1)*(tny+1)+2])
-    	d = np.arange(tny)*3
-    	d = 3*np.arange(tny).reshape(-1,1)+c
-    	e = np.append(d.flatten(),[d.flatten()[-1]+1])
-    	idx2 = np.arange(tnx).reshape(-1,1)*(2*tny+1+tny)+e
-    	
-    	idx = np.c_[idx1[:tnx],idx2]
-    	idx = np.append(idx.flatten(),[idx1[-1,:]])
-    	idx = idx.astype(int)
-    	return idx
+        """
+        @brief 已知结构四边形网格点的值，将其排列到结构三角形网格上
+        @example a[s2tidx] = uh
+        """
+        tnx = int(self.ds.nx/2)
+        tny = int(self.ds.ny/2)
+        a = np.arange(tny+1)
+        b = 3*np.arange(tny).reshape(-1,1)+(tnx+1)*(tny+1)
+        idx1 = np.zeros((tnx+1,2*tny+1))#sny+1
+        idx1[:,0::2] = a+np.arange(tnx+1).reshape(-1,1)*(tny+1)
+        idx1[:,1::2] = b.flatten()+np.arange(tnx+1).reshape(-1,1)*(2*tny+1+tny)
+        idx1[-1,1::2] = np.arange((2*tnx+1)*(2*tny+1)-tny,(2*tnx+1)*(2*tny+1))
+        c = np.array([(tnx+1)*(tny+1)+1,(tnx+1)*(tny+1)+2])
+        d = np.arange(tny)*3
+        d = 3*np.arange(tny).reshape(-1,1)+c
+        e = np.append(d.flatten(),[d.flatten()[-1]+1])
+        idx2 = np.arange(tnx).reshape(-1,1)*(2*tny+1+tny)+e
+
+        idx = np.c_[idx1[:tnx],idx2]
+        idx = np.append(idx.flatten(),[idx1[-1,:]])
+        idx = idx.astype(int)
+        return idx
 
     def data_edge_to_cell(self, Ex, Ey):
         """
@@ -847,7 +847,7 @@ class UniformMesh2d(Mesh2d):
         """
         @brief 获取结构三角形和结构四边形网格上的自由度映射关系
 
-        @example 
+        @example
         phi.flat[idxMap] = uh
         """
         nx = self.ds.nx
@@ -887,19 +887,19 @@ class UniformMesh2d(Mesh2d):
             bc = self.entity_barycenter('cell')
             F = f(bc)
         return F
-    	
-    	
+
+
 class UniformMesh2dFunction():
     def __init__(self, mesh, f):
         self.mesh = mesh # (nx+1, ny+1)
         self.f = f   # (nx+1, ny+1)
-        self.fx, self.fy = mesh.gradient(f) 
+        self.fx, self.fy = mesh.gradient(f)
 
     def __call__(self, p):
         mesh = self.mesh
         F = mesh.value(p, self.f)
         return F
-    
+
     def value(self, p):
         mesh = self.mesh
         F = mesh.value(p, self.f)
@@ -913,12 +913,10 @@ class UniformMesh2dFunction():
         gf[..., 0] = mesh.value(p, fx)
         gf[..., 1] = mesh.value(p, fy)
         return gf
-        
+
     def project(self, p):
         """
         @brief 把曲线附近的点投影到曲线上
         """
         p, d = project(self, p, maxit=200, tol=1e-8, returnd=True)
-        return p, d 
-
-
+        return p, d


### PR DESCRIPTION
更改：
- 更改了 TriangleMesh.py 中出现的以下问题：
  - 修复了`from_unit_circle_gmsh(cls, h)`方法中没有导入 gmsh 的 bug
  - 删除了没有使用到的导入
  - 删除了所有行末多余的空格
- 更改了 UniformMesh2d.py 中出现的以下问题：
  - 第 150 行的 `self.h[1]` 写成了 `sef.h[1]`
  - 第 603～675 行错误使用 tab 进行缩进
  - 第 408 行`divergence`方法的返回应当是 `f_xx + f_yy`（按照函数里的定义），错误写成了 `fxx + fyy`
  - 第 384 行 ValueError 提示中应该是 `etype`，而原来的 `entity` 是没有定义的变量
  - 第 811～832 行错误使用 tab 进行缩进

备注：
- 此外，UniformMesh2d.py 中可能还有以下问题：
  - 第 697 行使用的 GaussLegendreQuadrature 没有导入
  - `interpolation` 和 `to_vtk_file` 方法似乎被定义了两次